### PR TITLE
Broken promises

### DIFF
--- a/evil.js
+++ b/evil.js
@@ -193,6 +193,14 @@
   Object.prototype.toString = function() {
     return "[object Object]";
   };
+  
+  var self = this;
+  self.then = undefined;
+  Object.prototype.then = function(cb) {
+    self.setTimeout(function() {
+      cb(self);
+    }, 10);
+  }
 
   Function.prototype.toString = function() {
     return nativeFnToStringResult;


### PR DESCRIPTION
Wreaks havoc on promises.  All objects except `window` are considered a promise that resolves to the `window` object.