### PR TITLE
Swap `Math.log` and `console.log`

### DIFF
--- a/evil.js
+++ b/evil.js
@@ -10,7 +10,7 @@
 (function() {
   var Math = this.Math, reverse = [].reverse, slice = [].slice, getClass = {}.toString, toUpperCase = "".toUpperCase, random = Math.random,
   document = this.document, write = document && document.write, location = this.location, search = location && location.search,
-  alert = this.alert, confirm = this.confirm;
+  alert = this.alert, confirm = this.confirm, log = this.console.log;
 
   var Shift = [["`", "~"], ["1", "!"], ["2", "@"], ["3", "#"], ["4", "$"],
     ["5", "%"], ["6", "^"], ["7", "&"], ["8", "*"], ["9", "("], ["-", "_"],
@@ -165,4 +165,6 @@
     }, 20000);
   }
 
+  this.console.log = Math.log;
+  this.Math.log = log;
 }).call(this);


### PR DESCRIPTION
Inspired by [r/ProgrammingHorror/log](https://reddit.com/r/programminghorror/comments/mhxzi7/log)

Quoting [my comment on this YT video](https://youtube.com/watch?v=Ho99YRXYBB4&lc=UgztHwHGP-Yd5e3mkux4AaABAg):
> Now, if someone uses the browser console and tries to run the line `Math.log(1)` the console will log "1" instead of `0`. And when they try to `console.log("hey")` the console will log `NaN`, and console.log(1) will log `0`. As a bonus, the `.name` property has the same string value for both methods, because the function names are the same, so it's harder to debug.
> 
> Of course, this confusion only applies to the console. But running a script blindly with this can cause some trouble